### PR TITLE
Use io module to encode as UTF-8

### DIFF
--- a/pytest_variables/plugin.py
+++ b/pytest_variables/plugin.py
@@ -5,6 +5,7 @@
 import os.path
 import sys
 import warnings
+import io
 
 import pytest
 from functools import reduce
@@ -14,7 +15,7 @@ from pytest_variables import errors
 
 def default(module, path):
     try:
-        with open(path, 'rb') as f:
+        with io.open(path, 'r', encoding='utf8') as f:
             return module.load(f)
     except TypeError:
         # NOTE: python 3.2-3.5 json expects string,

--- a/pytest_variables/plugin.py
+++ b/pytest_variables/plugin.py
@@ -14,14 +14,7 @@ from pytest_variables import errors
 
 
 def default(module, path):
-    try:
-        with io.open(path, 'r', encoding='utf8') as f:
-            return module.load(f)
-    except TypeError:
-        # NOTE: python 3.2-3.5 json expects string,
-        # so we should rely on system encoding.
-        # This is fixed in newer versions.
-        with open(path) as f:
+     with io.open(path, 'r', encoding='utf8') as f:
             return module.load(f)
 
 

--- a/pytest_variables/plugin.py
+++ b/pytest_variables/plugin.py
@@ -14,9 +14,16 @@ from pytest_variables import errors
 
 
 def default(module, path):
-     with io.open(path, 'r', encoding='utf8') as f:
-            return module.load(f)
-
+      try:
+ -        with io.open(path, 'r', encoding='utf8') as f:
+ -            return module.load(f)
+ -    except TypeError:
+ -        # NOTE: python 3.2-3.5 json expects string,
+ -        # so we should rely on system encoding.
+ -        # This is fixed in newer versions.
+ -        with open(path) as f:
+ +             return module.load(f)
+  
 
 parser_table = {
     'json': ('json', default),


### PR DESCRIPTION
This allows variables files to contain non-ASCII characters without throwing an error.  Also requires edits to [pytest-selenium](https://github.com/pytest-dev/pytest-selenium/pull/148)